### PR TITLE
fix: Escape backslash in commit messages

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -58,7 +58,7 @@ export async function createPullByCurrentChanges({
 
   // Commit the changes
   await exec(`git add .`)
-  await exec(`git commit -m "${message.replace(/"/g, '\\"')}"`)
+  await exec(`git commit -m "${message.replace(/[\\"]/g, x => '\\' + x)}"`)
 
   // Push commits
   await exec(`git push -u origin ${branch} -f`)


### PR DESCRIPTION
Fixes #8

https://github.com/nandenjin/wp-updater-action/security/code-scanning/5